### PR TITLE
Document and fix some bugs in Sonic 3D music

### DIFF
--- a/s3d/music-improved/Ending.asm
+++ b/s3d/music-improved/Ending.asm
@@ -5,7 +5,16 @@ Snd_Ending_Header:
 	smpsHeaderTempo     $01, $10
 
 	smpsHeaderDAC       Snd_Ending_DAC
-	smpsHeaderFM        Snd_Ending_FM1,	$D5, $0B
+	; The $15 in the below line was $D5 in the original song data, but
+	; that is an invalid transpose value and creates notes which are
+	; impossibly low. In Sonic 3D's driver, these impossibly low notes
+	; would underflow and become higher notes, but other drivers
+	; (including Sonic 1 & 2's) will not handle this so gracefully, and
+	; instead produce incorrect notes.
+	; To address this, the value has been corrected to its
+	; post-underflow form, making it clear that this actually *raises*
+	; the pitch of the notes.
+	smpsHeaderFM        Snd_Ending_FM1,	$15, $0B
 	smpsHeaderFM        Snd_Ending_FM2,	$FD, $03
 	smpsHeaderFM        Snd_Ending_FM3,	$FD, $05
 	smpsHeaderFM        Snd_Ending_FM4,	$FD, $18

--- a/s3d/music-improved/Intro.asm
+++ b/s3d/music-improved/Intro.asm
@@ -5,7 +5,16 @@ Snd_Title_Header:
 	smpsHeaderTempo     $01, $04
 
 	smpsHeaderDAC       Snd_Title_DAC
-	smpsHeaderFM        Snd_Title_FM1,	$D4, $0B
+	; The $14 in the below line was $D4 in the original song data, but
+	; that is an invalid transpose value and creates notes which are
+	; impossibly low. In Sonic 3D's driver, these impossibly low notes
+	; would underflow and become higher notes, but other drivers
+	; (including Sonic 1 & 2's) will not handle this so gracefully, and
+	; instead produce incorrect notes.
+	; To address this, the value has been corrected to its
+	; post-underflow form, making it clear that this actually *raises*
+	; the pitch of the notes.
+	smpsHeaderFM        Snd_Title_FM1,	$14, $0B
 	smpsHeaderFM        Snd_Title_FM2,	$00, $03
 	smpsHeaderFM        Snd_Title_FM3,	$00, $05
 	smpsHeaderFM        Snd_Title_FM4,	$FC, $18

--- a/s3d/music-original/Ending.asm
+++ b/s3d/music-original/Ending.asm
@@ -5,6 +5,11 @@ Snd_Ending_Header:
 	smpsHeaderTempo     $01, $10
 
 	smpsHeaderDAC       Snd_Ending_DAC
+	; The $D5 in the below line is an invalid transpose value and
+	; creates notes which are impossibly low. In Sonic 3D's driver,
+	; these impossibly low notes would underflow and become higher
+	; notes, but other drivers (including Sonic 1 & 2's) will not handle
+	; this so gracefully, and instead produce incorrect notes.
 	smpsHeaderFM        Snd_Ending_FM1,	$D5, $0B
 	smpsHeaderFM        Snd_Ending_FM2,	$FD, $03
 	smpsHeaderFM        Snd_Ending_FM3,	$FD, $05

--- a/s3d/music-original/Intro.asm
+++ b/s3d/music-original/Intro.asm
@@ -5,6 +5,11 @@ Snd_Title_Header:
 	smpsHeaderTempo     $01, $04
 
 	smpsHeaderDAC       Snd_Title_DAC
+	; The $D4 in the below line is an invalid transpose value and
+	; creates notes which are impossibly low. In Sonic 3D's driver,
+	; these impossibly low notes would underflow and become higher
+	; notes, but other drivers (including Sonic 1 & 2's) will not handle
+	; this so gracefully, and instead produce incorrect notes.
 	smpsHeaderFM        Snd_Title_FM1,	$D4, $0B
 	smpsHeaderFM        Snd_Title_FM2,	$00, $03
 	smpsHeaderFM        Snd_Title_FM3,	$00, $05


### PR DESCRIPTION
Bizarrely, these songs exploit FM note underflow, breaking compatibility with SMPS drivers that don't generate their frequency octaves.