### PR TITLE
(SMPS2ASM) Prevent broken frequency envelope usage.

### DIFF
--- a/_smps2asm_inc.asm
+++ b/_smps2asm_inc.asm
@@ -297,7 +297,21 @@ smpsHeaderFM macro loc,pitch,vol
 smpsHeaderPSG macro loc,pitch,vol,mod,voice
 	CheckedChannelPointer loc
 	PSGPitchConvert pitch
-	dc.b	vol,mod,voice
+	dc.b	vol
+	; Frequency envelope
+	if (SonicDriverVer>=3) && (SourceDriver<3)
+		; In SMPS 68k Type 1, this byte is skipped and can contain garbage.
+		; Sonic 2's Oil Ocean Zone and Ending themes set this byte to a non-zero value which
+		; other drivers may try to process as valid data, so manually force it to 0 here.
+		dc.b	0
+	else
+		if (MOMPASS==2) && (SonicDriverVer<3) && (SourceDriver>=3) && (mod<>0)
+			message "This track header specifies a frequency envelope, but this driver does not support them."			
+		endif
+		dc.b	mod
+	endif
+	; Volume envelope
+	dc.b	voice
 	endm
 
 ; Header macros for SFX (not for music)


### PR DESCRIPTION
This should fix Sonic 2's Oil Ocean Zone and Ending themes accidentally using frequency envelopes in later drivers.

Additionally, a message is printed to the user if they try to use a song which relies on frequency envelopes with a driver that does not support them.