### PR TITLE
Fix more music bugs.

### DIFF
--- a/s1/music-improved/Mus91 - Credits.asm
+++ b/s1/music-improved/Mus91 - Credits.asm
@@ -724,7 +724,8 @@ Mus91_Credits_Loop29:
 	smpsLoop            $00, $04, Mus91_Credits_Loop29
 	smpsLoop            $01, $02, Mus91_Credits_Loop27
 	dc.b	nRst, $60, nRst, nRst, nRst, nRst, nRst, nRst, nRst, nRst
-	smpsAlterVol        $0C
+	; This erroneous FM-only command causes the following notes to be inaudible.
+	;smpsAlterVol        $0C
 	smpsAlterNote       $02
 	smpsPSGAlterVol     $02
 	dc.b	nRst, $0C, nE6, $06, nRst, nB6, nE6, $06, nRst, $0C, nE6, $06

--- a/s1/music-original/Mus91 - Credits.asm
+++ b/s1/music-original/Mus91 - Credits.asm
@@ -728,6 +728,7 @@ Mus91_Credits_Loop29:
 	smpsLoop            $00, $04, Mus91_Credits_Loop29
 	smpsLoop            $01, $02, Mus91_Credits_Loop27
 	dc.b	nRst, $60, nRst, nRst, nRst, nRst, nRst, nRst, nRst, nRst
+	; This erroneous FM-only command causes the following notes to be inaudible.
 	smpsAlterVol        $0C
 	smpsAlterNote       $02
 	smpsPSGAlterVol     $02

--- a/s3/music-optimized/Knuckles.asm
+++ b/s3/music-optimized/Knuckles.asm
@@ -5,7 +5,21 @@ Snd_Knux_Header:
 	smpsHeaderTempo     $01, $43
 
 	smpsHeaderDAC       Snd_Knux_DAC
-	smpsHeaderFM        Snd_Knux_FM1,	$C2, $03
+	; The transposition of $C2 is too low, causing the octave calculation to underflow.
+	; In drivers that don't calculate the octave (such as Sonic 1's and Sonic 2's
+	; drivers, which are derived from SMPS 68k Type 1b), this invalid transpose causes
+	; this channel's notes to play with nonsensical frequencies.
+	; Calculating the correct transposition is tricky because you have to consider that
+	; it's the sum of the transposition *with the note* that underflows the octave
+	; calculation, so the correct transposition depends on which notes it is used with.
+	; '(((x/12)&7)*12)+(x%12)' can be used to obtain a post-underflow version of the
+	; transpositon. Then, if the notes used with this transposition would cause the sum
+	; to exceed $60, then subtract $60 from the transposition.
+	; $C2 run through the formula is $02, and the notes that this displacement is used
+	; with are in the low octaves, so the sum will never exceed $60. Because of this,
+	; $02 is the correct displacement.
+	;smpsHeaderFM        Snd_Knux_FM1,	$C2, $03
+	smpsHeaderFM        Snd_Knux_FM1,	$02, $03 ; Fixed
 	smpsHeaderFM        Snd_Knux_FM2,	$E0, $18
 	smpsHeaderFM        Snd_Knux_FM3,	$0C, $10
 	smpsHeaderFM        Snd_Knux_FM4,	$00, $14

--- a/s3/music-optimized/Sonic 3 Miniboss.asm
+++ b/s3/music-optimized/Sonic 3 Miniboss.asm
@@ -5,7 +5,21 @@ Snd_Miniboss_Header:
 	smpsHeaderTempo     $01, $44
 
 	smpsHeaderDAC       Snd_Miniboss_DAC
-	smpsHeaderFM        Snd_Miniboss_FM1,	$C2, $03
+	; The transposition of $C2 is too low, causing the octave calculation to underflow.
+	; In drivers that don't calculate the octave (such as Sonic 1's and Sonic 2's
+	; drivers, which are derived from SMPS 68k Type 1b), this invalid transpose causes
+	; this channel's notes to play with nonsensical frequencies.
+	; Calculating the correct transposition is tricky because you have to consider that
+	; it's the sum of the transposition *with the note* that underflows the octave
+	; calculation, so the correct transposition depends on which notes it is used with.
+	; '(((x/12)&7)*12)+(x%12)' can be used to obtain a post-underflow version of the
+	; transpositon. Then, if the notes used with this transposition would cause the sum
+	; to exceed $60, then subtract $60 from the transposition.
+	; $C2 run through the formula is $02, and the notes that this displacement is used
+	; with are in the low octaves, so the sum will never exceed $60. Because of this,
+	; $02 is the correct displacement.
+	;smpsHeaderFM        Snd_Miniboss_FM1,	$C2, $03
+	smpsHeaderFM        Snd_Miniboss_FM1,	$02, $03 ; Fixed
 	smpsHeaderFM        Snd_Miniboss_FM2,	$0C, $0B
 	smpsHeaderFM        Snd_Miniboss_FM3,	$0C, $10
 	smpsHeaderFM        Snd_Miniboss_FM4,	$00, $14

--- a/s3/music/Knuckles.asm
+++ b/s3/music/Knuckles.asm
@@ -5,6 +5,19 @@ Snd_Knux_Header:
 	smpsHeaderTempo     $01, $43
 
 	smpsHeaderDAC       Snd_Knux_DAC
+	; The transposition of $C2 is too low, causing the octave calculation to underflow.
+	; In drivers that don't calculate the octave (such as Sonic 1's and Sonic 2's
+	; drivers, which are derived from SMPS 68k Type 1b), this invalid transpose causes
+	; this channel's notes to play with nonsensical frequencies.
+	; Calculating the correct transposition is tricky because you have to consider that
+	; it's the sum of the transposition *with the note* that underflows the octave
+	; calculation, so the correct transposition depends on which notes it is used with.
+	; '(((x/12)&7)*12)+(x%12)' can be used to obtain a post-underflow version of the
+	; transpositon. Then, if the notes used with this transposition would cause the sum
+	; to exceed $60, then subtract $60 from the transposition.
+	; $C2 run through the formula is $02, and the notes that this displacement is used
+	; with are in the low octaves, so the sum will never exceed $60. Because of this,
+	; $02 is the correct displacement.
 	smpsHeaderFM        Snd_Knux_FM1,	$C2, $03
 	smpsHeaderFM        Snd_Knux_FM2,	$E0, $18
 	smpsHeaderFM        Snd_Knux_FM3,	$0C, $10

--- a/s3/music/Sonic 3 Miniboss.asm
+++ b/s3/music/Sonic 3 Miniboss.asm
@@ -5,6 +5,19 @@ Snd_Miniboss_Header:
 	smpsHeaderTempo     $01, $44
 
 	smpsHeaderDAC       Snd_Miniboss_DAC
+	; The transposition of $C2 is too low, causing the octave calculation to underflow.
+	; In drivers that don't calculate the octave (such as Sonic 1's and Sonic 2's
+	; drivers, which are derived from SMPS 68k Type 1b), this invalid transpose causes
+	; this channel's notes to play with nonsensical frequencies.
+	; Calculating the correct transposition is tricky because you have to consider that
+	; it's the sum of the transposition *with the note* that underflows the octave
+	; calculation, so the correct transposition depends on which notes it is used with.
+	; '(((x/12)&7)*12)+(x%12)' can be used to obtain a post-underflow version of the
+	; transpositon. Then, if the notes used with this transposition would cause the sum
+	; to exceed $60, then subtract $60 from the transposition.
+	; $C2 run through the formula is $02, and the notes that this displacement is used
+	; with are in the low octaves, so the sum will never exceed $60. Because of this,
+	; $02 is the correct displacement.
 	smpsHeaderFM        Snd_Miniboss_FM1,	$C2, $03
 	smpsHeaderFM        Snd_Miniboss_FM2,	$0C, $0B
 	smpsHeaderFM        Snd_Miniboss_FM3,	$0C, $10


### PR DESCRIPTION
These fixes make a small extra portion of Sonic 1's credit music audible, and fix incorrect notes in Sonic 3's mini-boss and Knuckles music when ported to Sonic 1's and Sonic 2's drivers.