### PR TITLE
Document and fix another S1 Credits song bug.

### DIFF
--- a/s1/music-improved/Mus91 - Credits.asm
+++ b/s1/music-improved/Mus91 - Credits.asm
@@ -723,7 +723,10 @@ Mus91_Credits_Loop29:
 	dc.b	nA6, nA6, nE7, nA6, nD7, nA6, nC7, nA6
 	smpsLoop            $00, $04, Mus91_Credits_Loop29
 	smpsLoop            $01, $02, Mus91_Credits_Loop27
-	dc.b	nRst, $60, nRst, nRst, nRst, nRst, nRst, nRst, nRst, nRst
+	dc.b	nRst, $60, nRst, nRst, nRst, nRst, nRst
+	; These rests are unnecessary, and cause the following notes to play way too late.
+	; Delete these three notes to fix this.
+	;dc.b	nRst, nRst, nRst
 	; This erroneous FM-only command causes the following notes to be inaudible.
 	;smpsAlterVol        $0C
 	smpsAlterNote       $02

--- a/s1/music-original/Mus91 - Credits.asm
+++ b/s1/music-original/Mus91 - Credits.asm
@@ -727,7 +727,10 @@ Mus91_Credits_Loop29:
 	dc.b	nA6, nA6, nE7, nA6, nD7, nA6, nC7, nA6
 	smpsLoop            $00, $04, Mus91_Credits_Loop29
 	smpsLoop            $01, $02, Mus91_Credits_Loop27
-	dc.b	nRst, $60, nRst, nRst, nRst, nRst, nRst, nRst, nRst, nRst
+	dc.b	nRst, $60, nRst, nRst, nRst, nRst, nRst
+	; These rests are unnecessary, and cause the following notes to play way too late.
+	; Delete these three notes to fix this.
+	dc.b	nRst, nRst, nRst
 	; This erroneous FM-only command causes the following notes to be inaudible.
 	smpsAlterVol        $0C
 	smpsAlterNote       $02


### PR DESCRIPTION
This bug causes those inaudible notes to play at the wrong time. See [this thread](https://forums.sonicretro.org/index.php?posts/1016785/) for more information.